### PR TITLE
[#6314][Bug][API] when I delete the processDefinition, it's related task will also be deleted

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -645,6 +645,10 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         }
 
         int delete = processDefinitionMapper.deleteById(processDefinition.getId());
+        List<ProcessTaskRelation> processTaskRelations = processTaskRelationMapper.queryByProcessCode(project.getCode(), processDefinition.getCode());
+        for (ProcessTaskRelation processTaskRelation : processTaskRelations) {
+            taskDefinitionMapper.deleteByCode(processTaskRelation.getPostTaskCode());
+        }
         int deleteRelation = processTaskRelationMapper.deleteByCode(project.getCode(), processDefinition.getCode());
         if ((delete & deleteRelation) == 0) {
             putMsg(result, Status.DELETE_PROCESS_DEFINE_BY_CODE_ERROR);


### PR DESCRIPTION
when I delete the processDefinition, it's related task  will also be deleted

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
when I delete the processDefinition, it's related task will also be deleted

## Brief change log
when I delete the processDefinition, It will delete the processTaskRelation and the related task.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

